### PR TITLE
Start Phaser client and simple server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Phaser Roguelike Experiment
+
+This repository contains a small hobby project: a browser-based game inspired by *Realm of the Mad God*. It uses **Phaser** for rendering and aims to keep hosting costs at zero. The client can be served via free static hosting (such as GitHub Pages), and any multiplayer server is optional and can run locally.
+
+See [docs/plan.md](docs/plan.md) for the high-level development plan.

--- a/client/game.js
+++ b/client/game.js
@@ -1,0 +1,47 @@
+class MainScene extends Phaser.Scene {
+  constructor() {
+    super('main');
+  }
+
+  preload() {
+    this.load.image('player', 'https://labs.phaser.io/assets/sprites/phaser-dude.png');
+  }
+
+  create() {
+    this.player = this.physics.add.sprite(400, 300, 'player');
+    this.cursors = this.input.keyboard.createCursorKeys();
+  }
+
+  update() {
+    const speed = 200;
+    this.player.setVelocity(0);
+
+    if (this.cursors.left.isDown) {
+      this.player.setVelocityX(-speed);
+    } else if (this.cursors.right.isDown) {
+      this.player.setVelocityX(speed);
+    }
+
+    if (this.cursors.up.isDown) {
+      this.player.setVelocityY(-speed);
+    } else if (this.cursors.down.isDown) {
+      this.player.setVelocityY(speed);
+    }
+  }
+}
+
+const config = {
+  type: Phaser.AUTO,
+  width: 800,
+  height: 600,
+  physics: {
+    default: 'arcade',
+    arcade: {
+      gravity: { y: 0 },
+      debug: false,
+    },
+  },
+  scene: MainScene,
+};
+
+new Phaser.Game(config);

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Phaser Roguelike Experiment</title>
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
+  <style>
+    body { margin: 0; }
+    canvas { display: block; margin: 0 auto; }
+  </style>
+</head>
+<body>
+  <script src="game.js"></script>
+</body>
+</html>

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,43 @@
+# High-Level Project Plan
+
+This document outlines the high-level steps for creating a browser-based game inspired by **Realm of the Mad God** using **Phaser**.
+
+This project is intended as a quick hobby experiment. To keep costs at zero, the client will be hosted for free (for example via GitHub Pages) and any multiplayer server can run locally or on a free-tier service.
+## 1. Project Setup
+
+- **Framework**: Use Phaser for rendering and game logic.
+- **Directory Structure**:
+  - `client/` – browser code (Phaser, assets, UI).
+  - `server/` – optional Node.js server for multiplayer; run locally or on a free-tier service if needed.
+  - `docs/` – documentation and planning notes.
+- **Build/Tooling**: Consider bundlers like Vite or Webpack for the client. Use npm scripts for building and running.
+- **Version Control**: All code stored in this Git repository.
+
+## 2. Core Gameplay Prototype
+
+- Implement a single arena map.
+- Add player character with basic movement and shooting controls.
+- Spawn a few enemy types with simple AI (e.g., follow player, shoot projectiles).
+- Use placeholder graphics for early iterations.
+
+## 3. Multiplayer Foundations
+
+- Set up a Node.js WebSocket server to manage player sessions.
+- Server maintains authoritative state (positions, health, enemy spawns).
+- Exchange messages for movement, attacks, and game events between client and server.
+
+## 4. Expanding Features
+
+- Add RPG elements: leveling, experience, equipment.
+- Create additional maps or dungeons with increasing difficulty.
+- Include cooperative mechanics (e.g., group bosses) as development progresses.
+
+## 5. Testing & Deployment
+
+- Host the client via a static site (e.g., GitHub Pages).
+- If multiplayer is used, run the server locally or explore free hosting tiers.
+- Continuously test the multiplayer experience with friends and gather feedback.
+
+---
+
+This plan serves as a reference point for future development tasks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "phaser-roguelike-experiment",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "phaser-roguelike-experiment",
+      "version": "0.1.0",
+      "dependencies": {
+        "ws": "^8.15.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "phaser-roguelike-experiment",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start-server": "node server/server.js"
+  },
+  "dependencies": {
+    "ws": "^8.15.0"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,44 @@
+const WebSocket = require('ws');
+
+const wss = new WebSocket.Server({ port: 8080 });
+
+const players = new Map();
+
+wss.on('connection', function connection(ws) {
+  const id = Date.now() + Math.random().toString(36).substring(2);
+  players.set(ws, { id, x: 400, y: 300 });
+
+  ws.send(JSON.stringify({ type: 'init', id, players: Array.from(players.values()) }));
+
+  ws.on('message', function incoming(message) {
+    try {
+      const data = JSON.parse(message);
+      if (data.type === 'move') {
+        const player = players.get(ws);
+        if (!player) return;
+        player.x = data.x;
+        player.y = data.y;
+        broadcast({ type: 'update', id: player.id, x: player.x, y: player.y });
+      }
+    } catch (e) {
+      console.error('Failed to parse message', e);
+    }
+  });
+
+  ws.on('close', function() {
+    const player = players.get(ws);
+    players.delete(ws);
+    if (player) broadcast({ type: 'remove', id: player.id });
+  });
+});
+
+function broadcast(data) {
+  const msg = JSON.stringify(data);
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(msg);
+    }
+  }
+}
+
+console.log('WebSocket server running on port 8080');


### PR DESCRIPTION
## Summary
- set up Phaser client with a controllable player sprite
- add basic WebSocket server for syncing player movement
- initialize npm project and ignore node_modules

## Testing
- `npm run start-server` (server starts)

------
https://chatgpt.com/codex/tasks/task_e_6841e57d3df88322a9fabab228e1c87c